### PR TITLE
More normal json

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -26,7 +26,6 @@ func (h *handler) health(w http.ResponseWriter, r *http.Request) {
 
 func (h *handler) token(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	h.stats["requests"] += 1
@@ -34,6 +33,12 @@ func (h *handler) token(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(400)
 		return
 	}
+	h.giveToken(w, r)
+}
+
+func (h *handler) giveToken(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(500)
@@ -48,6 +53,7 @@ func (h *handler) token(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.WriteHeader(500)
 	}
+
 }
 
 func createMAC(message, key []byte) []byte {

--- a/handler.go
+++ b/handler.go
@@ -16,6 +16,7 @@ type handler struct {
 }
 
 func (h *handler) health(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	if r.Method != "GET" {
 		w.WriteHeader(400)
 		return

--- a/handler.go
+++ b/handler.go
@@ -16,10 +16,6 @@ type handler struct {
 	lock  sync.Mutex
 }
 
-type appMetrics struct {
-	Stats map[string]uint64 `json:"stats"`
-}
-
 func (h *handler) health(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 }
@@ -49,11 +45,11 @@ func (h *handler) metrics(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 
-	metric := appMetrics{}
-	metric.Stats = h.stats
-
 	// FIXME error not checked
-	enc.Encode(metric)
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	enc.Encode(h.stats)
 	// FIXME error not checked
 }
 

--- a/handler.go
+++ b/handler.go
@@ -16,9 +16,6 @@ type handler struct {
 	lock  sync.Mutex
 }
 
-type token struct {
-	Token []byte `json:"token"`
-}
 type appMetrics struct {
 	Stats map[string]uint64 `json:"stats"`
 }
@@ -44,16 +41,8 @@ func (h *handler) token(w http.ResponseWriter, r *http.Request) {
 			doInternalServerError(w, r, err)
 			return
 		}
-		metric := token{Token: out}
-		enc.Encode(metric)
+		enc.Encode(out)
 	}
-}
-
-func doInternalServerError(w http.ResponseWriter, r *http.Request, err error) {
-	enc := json.NewEncoder(w)
-	fmt.Println("error: ", err)
-	enc.Encode((err))
-	w.WriteHeader(500)
 }
 
 func (h *handler) metrics(w http.ResponseWriter, r *http.Request) {
@@ -72,4 +61,11 @@ func createMAC(message, key []byte) []byte {
 	mac := hmac.New(sha1.New, key)
 	mac.Write(message)
 	return mac.Sum(nil)
+}
+
+func doInternalServerError(w http.ResponseWriter, r *http.Request, err error) {
+	enc := json.NewEncoder(w)
+	fmt.Println("error: ", err)
+	enc.Encode((err))
+	w.WriteHeader(500)
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -29,12 +29,14 @@ func TestToken(t *testing.T) {
 		h.token(rec, req)
 
 		mac := createMAC([]byte(tt.body), h.key)
-		tok := token{}
+
+		var tok []byte
 		err := json.Unmarshal([]byte(rec.Body.Bytes()), &tok)
 		if err != nil {
 			panic(err)
 		}
-		actual := tok.Token
+		actual := tok
+
 		if !hmac.Equal(actual, mac) {
 			t.Errorf("failed to validate hmac")
 		}


### PR DESCRIPTION
- remove weird structs I made (that had json tags) now just returning more 'raw' but valid json
- amend test to take new shape of json -> note these tests are pretty brittle
- add lock around access to map (noticed that was another area where potential map access collision - confirmed this with concurrent siege  'attack')
- pulled out bulk of 'token' from handler because it was very large and hard to read